### PR TITLE
Navigation scroll fix

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2,11 +2,13 @@ import React, { useState } from 'react';
 import Providers from './providers';
 import { AppRoutes } from './router';
 import Layout from './layout';
+import WithNavigationScroll from './WithNavigationScroll';
 
 const App: React.FC = () => {
   return (
     <Providers>
       <Layout>
+        <WithNavigationScroll />
         <AppRoutes />
       </Layout>
     </Providers>

--- a/src/app/WithNavigationScroll.tsx
+++ b/src/app/WithNavigationScroll.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function WithNavigationScroll() {
+  const { pathname, hash } = useLocation();
+
+  useEffect(() => {
+    if (!hash) {
+      window.scrollTo(0, 0);
+    } else {
+      document.getElementById(hash.slice(1))?.scrollIntoView();
+    }
+  }, [pathname]);
+
+  return null;
+}

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -26,9 +26,5 @@ function assembleRoutes(options: RouteElement[]) {
 }
 
 export const AppRoutes = () => {
-  return (
-    <div>
-      <Routes>{assembleRoutes(routes)}</Routes>
-    </div>
-  );
+  return <Routes>{assembleRoutes(routes)}</Routes>;
 };


### PR DESCRIPTION
Since we use HashRouter, scroll functionality is not enforced. This adds this functionality back manually.